### PR TITLE
Add CI + CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    permissions: write-all
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+      
+      # Runs a single command using the runners shell
+      - name: ZIPs the contents
+        run: |
+          7z a -t7z -mx=9 -pmalte PowerOS11_Playbook.apbx ./ 
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: Playbook
+          path: PowerOS11_Playbook.apbx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Manual release action
+
+# Controls when the workflow will run
+on:
+  workflow_dispatch:
+    inputs:
+      nightly:
+        description: 'Is this pre-release?'
+        required: true
+        type: boolean
+      version:
+        description: 'Insert the version tag'
+        required: true
+        type: string
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    permissions: write-all
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+      
+      # Runs a single command using the runners shell
+      - name: ZIPs the contents
+        run: |
+          7z a -t7z -mx=9 -pmalte PowerOS11_Playbook.apbx ./ 
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: Playbook
+          path: PowerOS11_Playbook.apbx
+      - name: Create Relese
+        uses: ncipollo/release-action@v1.10.0
+        with:
+          artifacts: "PowerOS*"
+          tag: "v${{ inputs.version }}"
+          name: "PowerOS Playbook (${{ inputs.version }})"
+          prerelease: "${{ inputs.nightly }}"
+          bodyFile: "README.md"


### PR DESCRIPTION
This fork:
- Copies the CI from nano11 post setup with tweaks to make it work
- Adds two actions:
  - Build (automaticaly builds and releases as artifact every commit)
  - Release (allows to manually release a version)

- [x] Tests pass
- [x] No conflicts with upstream